### PR TITLE
Aroon indicators correction

### DIFF
--- a/pyti/aroon.py
+++ b/pyti/aroon.py
@@ -16,7 +16,7 @@ def aroon_up(data, period):
     period = int(period)
 
     a_up = [((period -
-            data[idx+1-period:idx+1].index(np.max(data[idx+1-period:idx+1]))) /
+            list(reversed(data[idx+1-period:idx+1])).index(np.max(data[idx+1-period:idx+1]))) /
             float(period)) * 100 for idx in range(period-1, len(data))]
     a_up = fill_for_noncomputable_vals(data, a_up)
     return a_up
@@ -33,7 +33,7 @@ def aroon_down(data, period):
     period = int(period)
 
     a_down = [((period -
-            data[idx+1-period:idx+1].index(np.min(data[idx+1-period:idx+1]))) /
+            list(reversed(data[idx+1-period:idx+1])).index(np.min(data[idx+1-period:idx+1]))) /
             float(period)) * 100 for idx in range(period-1, len(data))]
     a_down = fill_for_noncomputable_vals(data, a_down)
     return a_down


### PR DESCRIPTION
Hi, thanks for sharing your work.

I'm proposing here a correction to Aroon Indicators as follows:

According to: 
https://www.tradesignalonline.com/en/lexicon/view.aspx?id=AROON+Up%2FDown+Indicator+(AROON)
http://stockcharts.com/school/doku.php?id=chart_school:technical_indicators:aroon
https://www.tradingview.com/wiki/Aroon#CALCULATION
and to the formula provided in the code "AROONDWN = (((PERIOD) - (PERIODS SINCE PERIOD LOW)) / (PERIOD)) * 100"
Numerator calculation should be: 
   period - (period - index_of_maxormin_value) 
not just 
   (period - index_of_maxormin_value)

I used a reversed version of the list to fix the calculation in both Indicators.
Python 2 and 3 compatible.