### PR TITLE
Fix issue with negative RSI values

### DIFF
--- a/pyti/relative_strength_index.py
+++ b/pyti/relative_strength_index.py
@@ -18,11 +18,9 @@ def relative_strength_index(data, period):
     period = int(period)
     changes = [data_tup[1] - data_tup[0] for data_tup in zip(data[::1], data[1::1])]
 
-    filtered_gain = [val < 0 for val in changes]
-    gains = [0 if filtered_gain[idx] is True else changes[idx] for idx in range(0, len(filtered_gain))]
+    gains = [0 if val < 0 else val for val in changes]
 
-    filtered_loss = [val > 0 for val in changes]
-    losses = [0 if filtered_loss[idx] is True else abs(changes[idx]) for idx in range(0, len(filtered_loss))]
+    losses = [0 if val > 0 else abs(val) for val in changes]
 
     avg_gain = np.mean(gains[:period])
     avg_loss = np.mean(losses[:period])


### PR DESCRIPTION
The old list comprehensions were not filtering properly and negative RSI values were sneaking through.

These simplified comprehensions have worked well during my testing and improve readability.